### PR TITLE
Pull Timelines (minimum edits / draft 1)

### DIFF
--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -276,6 +276,7 @@ class Api:
             posts = sorted(result, key=lambda k: k["id"])
             params["max_id"] = posts[0]["id"]
 
+            breakpoint()
             most_recent_date = (
                 date_parse.parse(posts[-1]["created_at"])
                 .replace(tzinfo=timezone.utc)

--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -278,7 +278,7 @@ class Api:
 
             #breakpoint()
             most_recent_date = date_parse.parse(posts[-1]["created_at"]).replace(microsecond=0, tzinfo=timezone.utc)
-            if created_after and most_recent_date < created_after:
+            if created_after and most_recent_date <= created_after:
                 # Current and all future batches are too old
                 break
 

--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -279,7 +279,7 @@ class Api:
             most_recent_date = (
                 date_parse.parse(posts[-1]["created_at"])
                 .replace(tzinfo=timezone.utc)
-                .date()
+                # .date() # let's be more precise, using datetime instead of date, so we can still get statuses posted later in the same day as the latest previously collected status
             )
             if created_after and most_recent_date < created_after:
                 # Current and all future batches are too old

--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -290,7 +290,7 @@ class Api:
                 date_created = (
                     date_parse.parse(post["created_at"])
                     .replace(tzinfo=timezone.utc)
-                    .date()
+                    #.date() # let's be more precise, using datetime instead of date, so we can still get statuses posted later in the same day as the latest previously collected status
                 )
                 if created_after and date_created < created_after:
                     continue

--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -242,9 +242,12 @@ class Api:
                     return
 
     def pull_statuses(
-        self, username: str, created_after: date, replies: bool
+        self, username: str, created_after: datetime, replies: bool
     ) -> List[dict]:
-        """Pull the given user's statuses. Returns an empty list if not found."""
+        """Pull the given user's statuses. Returns an empty list if not found.
+
+            Params: created_after : currently needs to be a timezone-aware datetime object
+        """
 
         params = {}
         id = self.lookup(username)["id"]
@@ -276,7 +279,6 @@ class Api:
             posts = sorted(result, key=lambda k: k["id"])
             params["max_id"] = posts[0]["id"]
 
-            #breakpoint()
             most_recent_date = date_parse.parse(posts[-1]["created_at"]).replace(microsecond=0, tzinfo=timezone.utc)
             if created_after and most_recent_date <= created_after:
                 # Current and all future batches are too old

--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -276,23 +276,15 @@ class Api:
             posts = sorted(result, key=lambda k: k["id"])
             params["max_id"] = posts[0]["id"]
 
-            breakpoint()
-            most_recent_date = (
-                date_parse.parse(posts[-1]["created_at"])
-                .replace(tzinfo=timezone.utc)
-                # .date() # let's be more precise, using datetime instead of date, so we can still get statuses posted later in the same day as the latest previously collected status
-            )
+            #breakpoint()
+            most_recent_date = date_parse.parse(posts[-1]["created_at"]).replace(microsecond=0, tzinfo=timezone.utc)
             if created_after and most_recent_date < created_after:
                 # Current and all future batches are too old
                 break
 
             for post in posts:
                 post["_pulled"] = datetime.now().isoformat()
-                date_created = (
-                    date_parse.parse(post["created_at"])
-                    .replace(tzinfo=timezone.utc)
-                    #.date() # let's be more precise, using datetime instead of date, so we can still get statuses posted later in the same day as the latest previously collected status
-                )
+                date_created = date_parse.parse(post["created_at"]).replace(microsecond=0, tzinfo=timezone.utc)
                 if created_after and date_created < created_after:
                     continue
 


### PR DESCRIPTION
Updates `created_since` parameter of the `pull_statuses` function to be a datetime, instead of a date, so we can collect statuses posted later in the same day as some previously collected status.

We could alternatively consider using an approach based on status identifiers instead of status timestamps (if the identifiers are in ascending order).


(Minimal edits)
